### PR TITLE
feat: chart support cloudinary file storage

### DIFF
--- a/charts/directus/templates/configmap.yaml
+++ b/charts/directus/templates/configmap.yaml
@@ -18,6 +18,12 @@ data:
     STORAGE_LOCAL_DRIVER: "local"
     STORAGE_LOCAL_ROOT: {{ .Values.config.storage.local.root | quote }}
     {{- end }}
+    {{- if .Values.config.storage.remote.cloudinary.enabled }}
+    # Remote Storage
+    STORAGE_CLOUDINARY_DRIVER: "cloudinary"
+    STORAGE_CLOUDINARY_ROOT: {{ .Values.config.storage.remote.cloudinary.root | quote }}
+    STORAGE_CLOUDINARY_ACCESS_MODE: {{ .Values.config.storage.remote.cloudinary.access_mode | quote }}
+    {{- end }}
     # Authentication
     AUTH_PROVIDERS: {{ include "directus.authProviders" . | quote }}
     AUTH_DISABLE_DEFAULT: {{ ternary false true (.Values.config.auth.admin.enabled) }}

--- a/charts/directus/templates/deployment.yaml
+++ b/charts/directus/templates/deployment.yaml
@@ -89,6 +89,23 @@ spec:
                   name: {{ .Values.config.auth.sso.discord.existingSecret }}
                   key: {{ .Values.config.auth.sso.discord.existingSecretClientSecret }}
             {{- end }}
+            {{- if .Values.config.storage.remote.cloudinary.enabled }}
+            - name: STORAGE_CLOUDINARY_CLOUD_NAME
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.config.storage.remote.cloudinary.existingSecret }}
+                  key: {{ .Values.config.storage.remote.cloudinary.existingSecretCloudName }}
+            - name: STORAGE_CLOUDINARY_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.config.storage.remote.cloudinary.existingSecret }}
+                  key: {{ .Values.config.storage.remote.cloudinary.existingSecretApiKey }}
+            - name: STORAGE_CLOUDINARY_API_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.config.storage.remote.cloudinary.existingSecret }}
+                  key: {{ .Values.config.storage.remote.cloudinary.existingSecretApiSecret }}
+            {{- end }}
           volumeMounts:
           - name: config
             mountPath: /etc/{{ include "directus.fullname" . }}/config
@@ -114,9 +131,11 @@ spec:
           items:
           - key: config.yaml
             path: config.yaml
+      {{- if .Values.config.storage.local.enabled }}
       - name: app-local-storage
         persistentVolumeClaim:
           claimName: {{ if .Values.config.storage.local.existingClaim }}{{ .Values.config.storage.local.existingClaim }}{{- else }}{{ template "directus.fullname" . }}-pvc{{- end }}
+      {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/directus/values.yaml
+++ b/charts/directus/values.yaml
@@ -44,7 +44,7 @@ config:
     key: "6aeb8a0c-fdd5-4356-b5a8-c61fa83fc0ac"
     secret: "4c28b02f-6c4c-4e8d-a40f-fa5a25f3d691"
     public_url: https://cms.kolv.in
-    log_level: debug
+    log_level: warn
   storage:
     remote:
       s3:
@@ -53,12 +53,18 @@ config:
         enabled: false
       azure:
         enabled: false
-      cloudinary:
-        enabled: false
+      cloudinary: # https://docs.directus.io/self-hosted/config-options.html#cloudinary-cloudinary
+        enabled: false # broken driver -> https://github.com/directus/directus/issues/18146
+        root: /directus
+        access_mode: public
+        existingSecret: "directus-cloudinary"
+        existingSecretCloudName: cloud_name
+        existingSecretApiKey: api_key
+        existingSecretApiSecret: api_secret
     local:
-      enabled: true
+      enabled: false # Inability to avoid using internal /asset endpoint -> https://github.com/directus/directus/discussions/7612
       storageClassName: longhorn-fast
-      existingClaim: "directus-pvc"
+      # existingClaim: "directus-pvc"
       size: 8Gi
       root: /uploads
   auth:


### PR DESCRIPTION
+ chart support for enabling file storage via cloudinary

Blocked on usage as driver is broken when defining asset root, see ->  https://github.com/directus/directus/issues/18146